### PR TITLE
Just header info is enough for csv sniffer

### DIFF
--- a/pymws/utils.py
+++ b/pymws/utils.py
@@ -2,6 +2,7 @@ import base64
 from collections import namedtuple
 import hashlib
 
+from io import BytesIO
 from builtins import str
 import six
 
@@ -9,7 +10,6 @@ from .exceptions import MWSException
 
 if six.PY2:
     import unicodecsv as csv
-    from io import BytesIO
 else:
     import csv
 
@@ -150,7 +150,8 @@ def parse_xsv(text):
     Python 2 and 3 compatible (X)SV - CSV/TSV parser that returns a list of
     dictionary objects.
     """
-    dialect = csv.Sniffer().sniff(text)
+    header = BytesIO(text.encode("utf-8")).readline().decode("utf-8")
+    dialect = csv.Sniffer().sniff(header)
     if six.PY2:
         text = BytesIO(text.encode('utf-8'))
     else:


### PR DESCRIPTION
[ch7617]
Too much data confuses the heck out the csv sniffer and results
in wrong information. Just the header should be enough for it to
detect the dialect


## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request