### PR TITLE
Do not use quote as quotechar for parsing tsv/csv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/pymws/pymws.py
+++ b/pymws/pymws.py
@@ -1,6 +1,4 @@
 """Main module."""
-from __future__ import unicode_literals
-
 import base64
 import hashlib
 import hmac

--- a/pymws/utils.py
+++ b/pymws/utils.py
@@ -1,17 +1,12 @@
+import csv
 import base64
 from collections import namedtuple
 import hashlib
 
 from io import BytesIO
 from builtins import str
-import six
 
 from .exceptions import MWSException
-
-if six.PY2:
-    import unicodecsv as csv
-else:
-    import csv
 
 
 Marketplace = namedtuple(
@@ -152,17 +147,11 @@ def parse_xsv(text):
     """
     header = BytesIO(text.encode("utf-8")).readline().decode("utf-8")
     dialect = csv.Sniffer().sniff(header)
-    if six.PY2:
-        text = BytesIO(text.encode('utf-8'))
-    else:
-        text = text.split("\n")
 
     return list(
         csv.DictReader(
-            text,
-            delimiter=(
-                dialect.delimiter.encode() if six.PY2 else dialect.delimiter
-            )
+            text.split("\n"),
+            delimiter=dialect.delimiter
         )
     )
 

--- a/pymws/utils.py
+++ b/pymws/utils.py
@@ -151,7 +151,8 @@ def parse_xsv(text):
     return list(
         csv.DictReader(
             text.split("\n"),
-            delimiter=dialect.delimiter
+            delimiter=dialect.delimiter,
+            quotechar='•',
         )
     )
 

--- a/setup.py
+++ b/setup.py
@@ -14,17 +14,12 @@ requirements = [
     'Click>=7.0',
     'lxml',
     'requests',
-
-    # Drop these when py2 support is dropped
-    'future',
-    'six',
-    'unicodecsv',
 ]
 
 setup(
     author="Fulfil.IO Inc.",
     author_email='help@fulfil.io',
-    python_requires='>=2.7',
+    python_requires='>=3.5',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -35,7 +30,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 2.7',
     ],
     description="Python client for Amazon Marketplace Web Services (MWS)",
     entry_points={

--- a/tests/responses/reports/get_report_comma_separated.csv
+++ b/tests/responses/reports/get_report_comma_separated.csv
@@ -1,3 +1,3 @@
-"snapshot-date","fnsku","sku","product-name","quantity","fulfillment-center-id","detailed-disposition","country"
-"2021-05-24T00:00:00-07:00","test-1","test-1","test-1","1","YYZ4","SELLABLE","CA"
-"2021-05-24T00:00:00-07:00","test-2","test-2","test-2","1","YYZ4","SELLABLE","CA"
+snapshot-date,fnsku,sku,product-name,quantity,fulfillment-center-id,detailed-disposition,country
+2021-05-24T00:00:00-07:00,test-1,test-1,test-1,1,YYZ4,SELLABLE,CA
+2021-05-24T00:00:00-07:00,test-2,test-2,test-2,1,YYZ4,SELLABLE,CA

--- a/tests/test_fulfillment_intbound_shipment.py
+++ b/tests/test_fulfillment_intbound_shipment.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-
 def test_list_inbound_shipments(mws_client, mock_adapter, example_response):
     mock_adapter.register_uri(
         "GET",

--- a/tests/test_fulfillment_outbound_shipment.py
+++ b/tests/test_fulfillment_outbound_shipment.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import datetime
 
 

--- a/tests/test_pymws.py
+++ b/tests/test_pymws.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from datetime import datetime
 
 from click.testing import CliRunner


### PR DESCRIPTION
MWS reports doesn't escape quotes and when field contains quote,
reports gets parsed incorrectly.

This patch change quote char to • (unicode), to ignore quotes


## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request